### PR TITLE
Rename Example to Subpeep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
 	"pdsl_core",
 	# "pdsl_derive",
 	"pdsl_tests",
-	"examples/enzyme",
+	"examples/subpeep",
 ]
 
 [profile.release]

--- a/examples/subpeep/Cargo.toml
+++ b/examples/subpeep/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "enzyme"
+name = "subpeep"
 version = "0.1.0"
 authors = ["Robin Freyler <robin@parity.io>", "Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -14,7 +14,7 @@ wee_alloc = "0.4"
 lazy_static = "1.2"
 
 [lib]
-name = "enzyme"
+name = "subpeep"
 
 [features]
 default = []

--- a/examples/subpeep/README.md
+++ b/examples/subpeep/README.md
@@ -7,20 +7,20 @@ Decentralized message distribution inspired by Twitter.
 ### Required
 
 - Register users by their name.
-- Checks if the account is allowed to tweet.
-- Users can tweet messages that are prodcasted to the global channel.
+- Checks if the account is allowed to peep.
+- Users can peep messages that are prodcasted to the global channel.
 - Users can follow other users by their name.
 
 ## Data Structures
 
 ```rust
-// All global tweets.
-GLOBAL_TWEETS = [Tweet; 10]
+// All global peeps.
+GLOBAL_TWEETS = [Peep; 10]
 
 // The address for the registered user
 AUTH = mapping Username -> Address
-// All tweets by a single user
-USER_TWEETS = mapping Username -> Vec<Tweet>
+// All peeps by a single user
+USER_TWEETS = mapping Username -> Vec<Peep>
 // All users that this user is following
 USER_FOLLOWS = mapping Username -> Vec<Username>
 ```
@@ -33,9 +33,9 @@ USER_FOLLOWS = mapping Username -> Vec<Username>
 fn register(username)
     AUTH[username] = caller()
 
-fn tweet(username, tweet)
+fn peep(username, peep)
     if AUTH[username] = caller()
-        TWEETS[username].append(tweet)
+        TWEETS[username].append(peep)
 
 fn follow(username: String, followed: String)
     if AUTH[username] == caller() and AUTH[followed].is_some()

--- a/examples/subpeep/README.md
+++ b/examples/subpeep/README.md
@@ -15,12 +15,12 @@ Decentralized message distribution inspired by Twitter.
 
 ```rust
 // All global peeps.
-GLOBAL_TWEETS = [Peep; 10]
+GLOBAL_PEEPS = [Peep; 10]
 
 // The address for the registered user
 AUTH = mapping Username -> Address
 // All peeps by a single user
-USER_TWEETS = mapping Username -> Vec<Peep>
+USER_PEEPS = mapping Username -> Vec<Peep>
 // All users that this user is following
 USER_FOLLOWS = mapping Username -> Vec<Username>
 ```
@@ -35,7 +35,7 @@ fn register(username)
 
 fn peep(username, peep)
     if AUTH[username] = caller()
-        TWEETS[username].append(peep)
+        PEEPS[username].append(peep)
 
 fn follow(username: String, followed: String)
     if AUTH[username] == caller() and AUTH[followed].is_some()

--- a/examples/subpeep/README.md
+++ b/examples/subpeep/README.md
@@ -1,4 +1,4 @@
-# Enzyme
+# Subpeep
 
 Decentralized message distribution inspired by Twitter.
 

--- a/examples/subpeep/src/lib.rs
+++ b/examples/subpeep/src/lib.rs
@@ -41,7 +41,7 @@ impl UserData {
 	///
 	/// The `CellChunkAlloc` should be preferred here since
 	/// allocations of this type are dynamic. For this reason
-	/// the `Enzyme` type has a built-in `CellChunkAlloc`.
+	/// the `Subpeep` type has a built-in `CellChunkAlloc`.
 	pub unsafe fn new_using_alloc<A>(alloc: &mut A) -> Self
 	where
 		A: storage::Allocator
@@ -53,8 +53,8 @@ impl UserData {
 	}
 }
 
-/// The entire enzyme contract.
-pub struct Enzyme {
+/// The entire subpeep contract.
+pub struct Subpeep {
 	/// All tweets done by all users.
 	tweets: storage::Vec<Tweet>,
 	/// Database of all registered users and their data.
@@ -63,18 +63,18 @@ pub struct Enzyme {
 	alloc: storage::alloc::CellChunkAlloc,
 }
 
-impl Default for Enzyme {
+impl Default for Subpeep {
 	fn default() -> Self {
 		unsafe {
-			Enzyme::new_using_alloc(
+			Subpeep::new_using_alloc(
 				&mut* utils::STORAGE_ALLOC.lock().unwrap()
 			)
 		}
 	}
 }
 
-impl Enzyme {
-	/// Creates new enzyme platform using the given allocator.
+impl Subpeep {
+	/// Creates new subpeep platform using the given allocator.
 	///
 	/// # Note
 	///

--- a/examples/subpeep/src/lib.rs
+++ b/examples/subpeep/src/lib.rs
@@ -8,18 +8,18 @@ pub mod utils;
 use pdsl_core::storage;
 use parity_codec_derive::{Encode, Decode};
 
-/// A tweet done by a registered user.
+/// A peep done by a registered user.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[derive(Encode, Decode)]
-pub struct Tweet {
-	/// By whom the tweet was done.
+pub struct Peep {
+	/// By whom the peep was done.
 	by: String,
-	/// The message of the tweet.
+	/// The message of the peep.
 	message: String,
 }
 
-impl Tweet {
-	/// Creates a new tweet from `by` with content `message`.
+impl Peep {
+	/// Creates a new peep from `by` with content `message`.
 	pub fn new(by: String, message: String) -> Self {
 		Self{by, message}
 	}
@@ -28,8 +28,8 @@ impl Tweet {
 /// The data of a registered user.
 #[derive(Encode, Decode)]
 pub struct UserData {
-	/// The tweets.
-	tweets: storage::Vec<String>,
+	/// The peeps.
+	peeps: storage::Vec<String>,
 	/// The follows.
 	following: storage::Vec<String>,
 }
@@ -47,7 +47,7 @@ impl UserData {
 		A: storage::Allocator
 	{
 		Self {
-			tweets: storage::Vec::new_using_alloc(alloc),
+			peeps: storage::Vec::new_using_alloc(alloc),
 			following: storage::Vec::new_using_alloc(alloc),
 		}
 	}
@@ -55,8 +55,8 @@ impl UserData {
 
 /// The entire subpeep contract.
 pub struct Subpeep {
-	/// All tweets done by all users.
-	tweets: storage::Vec<Tweet>,
+	/// All peeps done by all users.
+	peeps: storage::Vec<Peep>,
 	/// Database of all registered users and their data.
 	users: storage::HashMap<String, UserData>,
 	/// The allocator for newly allocated entities.
@@ -86,16 +86,16 @@ impl Subpeep {
 		A: pdsl_core::storage::Allocator
 	{
 		Self {
-			tweets: storage::Vec::new_using_alloc(alloc),
+			peeps: storage::Vec::new_using_alloc(alloc),
 			users: storage::HashMap::new_using_alloc(alloc),
 			alloc: storage::alloc::CellChunkAlloc::new_using_alloc(alloc),
 		}
 	}
 
 	/// Returns all recent global posts as vector.
-	pub(crate) fn recent_tweets(&self, amount: usize) -> Vec<Tweet> {
+	pub(crate) fn recent_peeps(&self, amount: usize) -> Vec<Peep> {
 		self
-			.tweets
+			.peeps
 			.iter()
 			.rev()
 			.take(amount)
@@ -103,26 +103,26 @@ impl Subpeep {
 			.collect()
 	}
 
-	/// Returns the `n` most recent tweets of the given user.
+	/// Returns the `n` most recent peeps of the given user.
 	///
 	/// Returns `None` if the user does not exist.
-	pub(crate) fn recent_user_tweets(
+	pub(crate) fn recent_user_peeps(
 		&self,
 		amount: usize,
 		username: &str,
-	) -> Option<Vec<Tweet>> {
+	) -> Option<Vec<Peep>> {
 		self
 			.users
 			.get(username)
 			.map(|user| {
 				user
-					.tweets
+					.peeps
 					.iter()
 					.rev()
 					.take(amount)
 					.cloned()
 					.map(|message| {
-						Tweet::new(username.into(), message)
+						Peep::new(username.into(), message)
 					})
 					.collect()
 			})
@@ -131,8 +131,8 @@ impl Subpeep {
 	/// Posts a message to the global channel.
 	/// 
 	/// Will only ever store the latest 10 messages in the channel at most.
-	fn tweet_global(&mut self, username: &str, message: &str) {
-		self.tweets.push(Tweet::new(username.into(), message.into()))
+	fn peep_global(&mut self, username: &str, message: &str) {
+		self.peeps.push(Peep::new(username.into(), message.into()))
 	}
 
 	/// Register a new user.
@@ -148,12 +148,12 @@ impl Subpeep {
 	}
 
 	/// Post a message by a user.
-	pub fn tweet_message(&mut self, username: &str, message: &str) {
-		self.tweet_global(username, message);
+	pub fn peep_message(&mut self, username: &str, message: &str) {
+		self.peep_global(username, message);
 		self
 			.users
 			.mutate_with(username, |user| {
-				user.tweets.push(message.into())
+				user.peeps.push(message.into())
 			});
 	}
 

--- a/examples/subpeep/src/tests.rs
+++ b/examples/subpeep/src/tests.rs
@@ -4,30 +4,30 @@ use super::*;
 fn deploy() {
 	let subpeep = Subpeep::default();
 	assert_eq!(
-		subpeep.recent_tweets(10),
+		subpeep.recent_peeps(10),
 		vec![]
 	);
 	assert_eq!(
-		subpeep.recent_user_tweets(10, "alice"),
+		subpeep.recent_user_peeps(10, "alice"),
 		None
 	);
 }
 
 #[test]
-fn tweet_message() {
+fn peep_message() {
 	let mut subpeep = Subpeep::default();
 	let test_user = "Alice";
 	let test_message = "Hello, World!";
 	subpeep.register(test_user.into());
-	subpeep.tweet_message(test_user.into(), test_message.into());
+	subpeep.peep_message(test_user.into(), test_message.into());
 	assert_eq!(
-		subpeep.recent_tweets(10),
-		vec![Tweet::new(test_user.into(), test_message.into())],
+		subpeep.recent_peeps(10),
+		vec![Peep::new(test_user.into(), test_message.into())],
 	);
 	assert_eq!(
-		subpeep.recent_user_tweets(10, test_user.into()),
+		subpeep.recent_user_peeps(10, test_user.into()),
 		Some(vec![
-			Tweet::new(test_user.into(), test_message.into())
+			Peep::new(test_user.into(), test_message.into())
 		])
 	);
 }

--- a/examples/subpeep/src/tests.rs
+++ b/examples/subpeep/src/tests.rs
@@ -2,30 +2,30 @@ use super::*;
 
 #[test]
 fn deploy() {
-	let enzyme = Enzyme::default();
+	let subpeep = Subpeep::default();
 	assert_eq!(
-		enzyme.recent_tweets(10),
+		subpeep.recent_tweets(10),
 		vec![]
 	);
 	assert_eq!(
-		enzyme.recent_user_tweets(10, "alice"),
+		subpeep.recent_user_tweets(10, "alice"),
 		None
 	);
 }
 
 #[test]
 fn tweet_message() {
-	let mut enzyme = Enzyme::default();
+	let mut subpeep = Subpeep::default();
 	let test_user = "Alice";
 	let test_message = "Hello, World!";
-	enzyme.register(test_user.into());
-	enzyme.tweet_message(test_user.into(), test_message.into());
+	subpeep.register(test_user.into());
+	subpeep.tweet_message(test_user.into(), test_message.into());
 	assert_eq!(
-		enzyme.recent_tweets(10),
+		subpeep.recent_tweets(10),
 		vec![Tweet::new(test_user.into(), test_message.into())],
 	);
 	assert_eq!(
-		enzyme.recent_user_tweets(10, test_user.into()),
+		subpeep.recent_user_tweets(10, test_user.into()),
 		Some(vec![
 			Tweet::new(test_user.into(), test_message.into())
 		])

--- a/examples/subpeep/src/utils.rs
+++ b/examples/subpeep/src/utils.rs
@@ -43,7 +43,7 @@ enum Action {
 	/// Register a new user.
 	Register{username: String},
 	/// Post a message by a user.
-	TweetMessage{username: String, message: String},
+	PeepMessage{username: String, message: String},
 	/// Make a user follow the other.
 	Follow{following: String, followed: String},
 }
@@ -66,8 +66,8 @@ pub extern "C" fn call() {
 		Action::Register{username} => {
 			subpeep.register(&username);
 		}
-		Action::TweetMessage{username, message} => {
-			subpeep.tweet_message(&username, &message)
+		Action::PeepMessage{username, message} => {
+			subpeep.peep_message(&username, &message)
 		}
 		Action::Follow{following, followed} => {
 			subpeep.follow(&following, &followed)

--- a/examples/subpeep/src/utils.rs
+++ b/examples/subpeep/src/utils.rs
@@ -37,7 +37,7 @@ lazy_static! {
 	};
 }
 
-/// Enzyme API.
+/// Subpeep API.
 #[derive(Encode, Decode)]
 enum Action {
 	/// Register a new user.
@@ -61,16 +61,16 @@ pub extern "C" fn call() {
 	let input = ContractEnv::input();
 	let action = Action::decode(&mut &input[..]).unwrap();
 
-	let mut enzyme = crate::Enzyme::default();
+	let mut subpeep = crate::Subpeep::default();
 	match action {
 		Action::Register{username} => {
-			enzyme.register(&username);
+			subpeep.register(&username);
 		}
 		Action::TweetMessage{username, message} => {
-			enzyme.tweet_message(&username, &message)
+			subpeep.tweet_message(&username, &message)
 		}
 		Action::Follow{following, followed} => {
-			enzyme.follow(&following, &followed)
+			subpeep.follow(&following, &followed)
 		}
 	}
 }


### PR DESCRIPTION
Fix the misunderstanding of the project name and fix it. Renames the 
(currently wrongly named) example Enzyme into Subpeep - from substrate + 
echoism 'peep'. In the same vain, rename `Tweet` into `Peep` and all API 
accordingly.