### PR TITLE
Remove +nightly qualifier because of rust-toolchain

### DIFF
--- a/cli/src/cmd/new.rs
+++ b/cli/src/cmd/new.rs
@@ -149,7 +149,7 @@ fn build_sh_contents(name: &str) -> String {
 PROJNAME={}
 
 CARGO_INCREMENTAL=0 &&
-cargo +nightly build --release --target=wasm32-unknown-unknown --verbose &&
+cargo build --release --target=wasm32-unknown-unknown --verbose &&
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm &&
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat &&
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat &&

--- a/examples/core/erc20/build.sh
+++ b/examples/core/erc20/build.sh
@@ -10,7 +10,7 @@ PROJNAME=erc20
 cargo clean
 rm Cargo.lock
 
-CARGO_INCREMENTAL=0 cargo +nightly build --release --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/core/incrementer/build.sh
+++ b/examples/core/incrementer/build.sh
@@ -8,7 +8,7 @@
 PROJNAME=incrementer
 #cargo clean
 #rm Cargo.lock
-CARGO_INCREMENTAL=0 cargo +nightly build --release --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/core/noop/build.sh
+++ b/examples/core/noop/build.sh
@@ -8,7 +8,7 @@
 PROJNAME=noop
 #cargo clean
 #rm Cargo.lock
-CARGO_INCREMENTAL=0 cargo +nightly build --release --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/core/subpeep/build.sh
+++ b/examples/core/subpeep/build.sh
@@ -8,7 +8,7 @@
 PROJNAME=subpeep
 #cargo clean
 #rm Cargo.lock
-CARGO_INCREMENTAL=0 cargo +nightly build --release --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/lang/erc20/build.sh
+++ b/examples/lang/erc20/build.sh
@@ -5,7 +5,7 @@ PROJNAME=erc20
 cargo clean
 rm Cargo.lock
 
-CARGO_INCREMENTAL=0 cargo +nightly build --release --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/model/erc20/build.sh
+++ b/examples/model/erc20/build.sh
@@ -8,7 +8,7 @@
 PROJNAME=erc20
 #cargo clean
 #rm Cargo.lock
-CARGO_INCREMENTAL=0 cargo +nightly build --release --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/model/incrementer/build.sh
+++ b/examples/model/incrementer/build.sh
@@ -8,7 +8,7 @@
 PROJNAME=incrementer
 #cargo clean
 #rm Cargo.lock
-CARGO_INCREMENTAL=0 cargo +nightly build --release --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat


### PR DESCRIPTION
This repository already has rust-toolchain file, but at the present in all build.sh there are inconsisency:

the first cargo invocation is without a qualifier
then the second cargo invocation is with +nightly qualifier

this means that build.sh will typically download the required toolchain, but then will use `nightly`. This might be a problem if `nightly` version is outdated.
